### PR TITLE
Fix Vulkan physical device creation

### DIFF
--- a/src/dawn/native/vulkan/BackendVk.cpp
+++ b/src/dawn/native/vulkan/BackendVk.cpp
@@ -516,7 +516,7 @@ ResultOrError<std::vector<Ref<PhysicalDeviceBase>>> Backend::DiscoverAdapters(
         }
         const std::vector<VkPhysicalDevice>& vkPhysicalDevices =
             mVulkanInstances[icd]->GetVkPhysicalDevices();
-        for (uint32_t i = 0; i < physicalDevices.size(); ++i) {
+        for (uint32_t i = 0; i < vkPhysicalDevices.size(); ++i) {
             Ref<PhysicalDevice> physicalDevice = AcquireRef(
                 new PhysicalDevice(instance, mVulkanInstances[icd].Get(), vkPhysicalDevices[i],
                                    options->openXRConfig));


### PR DESCRIPTION
Hi,

There seems to be a typo when calling ``DiscoverAdapters``, without this change no adapters are found. Now it's the same as in the [main dawn repo](https://dawn.googlesource.com/dawn/+/refs/heads/main/src/dawn/native/vulkan/BackendVk.cpp#499).

I've finally been able to draw a triangle with WebGPU and OpenXR in my Quest 2 :) Many thanks for your work!